### PR TITLE
Deprecated ArrayInterface in favour of ancestor OptionSourceInterface

### DIFF
--- a/lib/internal/Magento/Framework/Option/ArrayInterface.php
+++ b/lib/internal/Magento/Framework/Option/ArrayInterface.php
@@ -6,7 +6,9 @@
 namespace Magento\Framework\Option;
 
 /**
- * @todo Remove in favor of the ancestor interface
+ * Array marker interface
+ *
+ * @deprecated please use Magento\Framework\Data\OptionSourceInterface instead.
  */
 interface ArrayInterface extends \Magento\Framework\Data\OptionSourceInterface
 {

--- a/lib/internal/Magento/Framework/Option/ArrayInterface.php
+++ b/lib/internal/Magento/Framework/Option/ArrayInterface.php
@@ -8,7 +8,8 @@ namespace Magento\Framework\Option;
 /**
  * Array marker interface
  *
- * @deprecated please use Magento\Framework\Data\OptionSourceInterface instead.
+ * @deprecated please use \Magento\Framework\Data\OptionSourceInterface instead.
+ * @see \Magento\Framework\Data\OptionSourceInterface
  */
 interface ArrayInterface extends \Magento\Framework\Data\OptionSourceInterface
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Marked Magento\Framework\Option\ArrayInterface as deprecated in favour of ancestor Magento\Framework\Data\OptionSourceInterface
Please see https://github.com/magento/magento2/pull/19308 with further replacements

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
n/a

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
n/a

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
